### PR TITLE
Fix index out of range error on check cmd

### DIFF
--- a/cmd/all.go
+++ b/cmd/all.go
@@ -34,6 +34,7 @@ var allCmd = &cobra.Command{
 			logger.Error(err)
 		}
 
+		fmt.Println("")
 		logger.Success("")
 	},
 }

--- a/domain/service/check.go
+++ b/domain/service/check.go
@@ -31,9 +31,12 @@ func CheckFiles(srcDir, ansFile string, probs model.Problems) (model.Problems, e
 		}
 
 		score := 0
-		for i, pl := range ansLines {
-			if pl == probLines[i] {
-				score++
+
+		if len(probLines) >= len(ansLines) {
+			for i, pl := range ansLines {
+				if pl == probLines[i] {
+					score++
+				}
 			}
 		}
 


### PR DESCRIPTION
Closes #40 

- [x] Fix a for-loop in service/check.go